### PR TITLE
Add Outreach Call Alert on Patient Dashboard page

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-query": "^2.5.13",
     "react-router-dom": "^5.2.0",
     "react-switch": "^6.0.0",
+    "remixicon": "^2.5.0",
     "resolve": "1.15.0",
     "resolve-url-loader": "3.1.1",
     "sass-loader": "8.0.2",

--- a/src/components/AddPatientForm.tsx
+++ b/src/components/AddPatientForm.tsx
@@ -152,6 +152,7 @@ const AddPatientForm: React.FC = () => {
           yes: false,
           lastMessageSent: "0",
           lastDate: new Date(),
+          pending: true,
         },
       })
       .then((res) => {

--- a/src/components/AddPatientForm.tsx
+++ b/src/components/AddPatientForm.tsx
@@ -151,6 +151,7 @@ const AddPatientForm: React.FC = () => {
           more: false,
           yes: false,
           lastMessageSent: "0",
+          messageCount: 0,
           lastDate: new Date(),
           pending: true,
         },

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import styled, { createGlobalStyle } from "styled-components";
+import styled, { ThemeProvider } from "styled-components";
 
 export interface SortOption {
   // the field in data to use
@@ -74,6 +74,7 @@ const TableCell = styled.td`
 
 const BodyRow = styled.tr`
   border-bottom: 1px solid #c4c4c4;
+  background-color: ${(props) => props.theme.backgroundColor};
 `;
 
 const TableContainer = styled.div`
@@ -140,6 +141,12 @@ const Table: React.FC<TableProps> = ({
   options,
   query,
 }: TableProps) => {
+  const getBodyRowTheme = (backgroundColor: string) => {
+    return {
+      backgroundColor: backgroundColor,
+    };
+  };
+
   // set default sort to marked default, or null if no sorts provided
   const defaultSort =
     options.sortOptions && options.sortOptions.length >= 1
@@ -230,15 +237,21 @@ const Table: React.FC<TableProps> = ({
           {sortedData
             .slice(page * perPage, (page + 1) * perPage)
             .map((row: any, ind) => (
-              <BodyRow key={`${ind}`}>
-                {columns.map((col) => (
-                  <TableCell key={`${col.key}-${ind}`}>
-                    {typeof col.data == "string"
-                      ? row[col.data]
-                      : col.data(row)}
-                  </TableCell>
-                ))}
-              </BodyRow>
+              <ThemeProvider
+                theme={getBodyRowTheme(
+                  row?.outreach?.yes && row?.outreach?.pending ? "red" : "white"
+                )}
+              >
+                <BodyRow key={`${ind}`}>
+                  {columns.map((col) => (
+                    <TableCell key={`${col.key}-${ind}`}>
+                      {typeof col.data == "string"
+                        ? row[col.data]
+                        : col.data(row)}
+                    </TableCell>
+                  ))}
+                </BodyRow>
+              </ThemeProvider>
             ))}
         </tbody>
       </StyledTable>

--- a/src/pages/AppRouter.tsx
+++ b/src/pages/AppRouter.tsx
@@ -4,7 +4,7 @@ import Login from "./Login";
 import Dashboard from "./Dashboard";
 import Profile from "./Profile";
 import MessageTemplatePage from "./MessageTemplates";
-import PatientDashboard from "./PatientDashboard";
+import PatientDashboard from "./PatientDashboard/PatientDashboard";
 import PatientRecords from "./PatientRecords/PatientRecords";
 import AddPatientForm from "../components/AddPatientForm";
 import MessageTemplateForm from "../components/MessageTemplateForm";

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import Sidebar from "../components/Sidebar/Sidebar";
 
 const FlexContainer = styled.div`
   display: flex;
+  margin-left: 10%;
 `;
 
 const ContentContainer = styled.div`

--- a/src/pages/PatientDashboard/PatientDashboard.tsx
+++ b/src/pages/PatientDashboard/PatientDashboard.tsx
@@ -1,11 +1,16 @@
 import React, { useState } from "react";
 import styled, { createGlobalStyle } from "styled-components";
-import Table, { Column, SortOption, TableOptions } from "../components/Table";
-import SearchBar from "../components/SearchBar";
-import EnableSwitch from "../components/EnableSwitch";
+import Table, {
+  Column,
+  SortOption,
+  TableOptions,
+} from "../../components/Table";
+import SearchBar from "../../components/SearchBar";
+import EnableSwitch from "../../components/EnableSwitch";
+import OutreachAlert from "./components/OutreachAlert";
 import { useQuery } from "react-query";
-import auth from "../api/core/auth";
-import { fetchMe, getPatients } from "../api/userApi";
+import auth from "../../api/core/auth";
+import { fetchMe, getPatients } from "../../api/userApi";
 
 const DashboardContainer = styled.div`
   padding: 20px;
@@ -138,6 +143,17 @@ const tableOptions: TableOptions = {
 
 const cols: Column[] = [
   {
+    name: "Outreach call",
+    data: (row) => (
+      <OutreachAlert
+        _id={row._id}
+        outreachYesStatus={row?.outreach?.yes || false}
+        pending={row?.outreach?.pending || false}
+      />
+    ),
+    key: "outreach",
+  },
+  {
     name: "Status",
     data: "status",
     key: "status",
@@ -196,26 +212,6 @@ const cols: Column[] = [
   },
 ];
 
-const UnreadButton = styled.button`
-  width: 100%;
-  background-color: #fad246 !important;
-  font-size: 13px !important;
-  border-radius: 15px !important;
-  color: white !important;
-  border: none !important;
-  font-weight: 600;
-
-  &:hover {
-    box-shadow: 5px 5px 10px rgba(221, 225, 231, 1) !important;
-    border: none !important;
-  }
-
-  &:focus {
-    box-shadow: 5px 5px 10px rgba(221, 225, 231, 1) !important;
-    border: none !important;
-  }
-`;
-
 const ViewButton = styled.button`
   width: 100%;
   background-color: #f29da4 !important;
@@ -234,11 +230,6 @@ const ViewButton = styled.button`
     box-shadow: 5px 5px 10px rgba(221, 225, 231, 1) !important;
     border: none !important;
   }
-`;
-
-const ActiveText = styled.p`
-  color: #b4d983;
-  font-weight: 800;
 `;
 
 export default PatientDashboard;

--- a/src/pages/PatientDashboard/PatientDashboard.tsx
+++ b/src/pages/PatientDashboard/PatientDashboard.tsx
@@ -1,13 +1,10 @@
 import React, { useState } from "react";
 import styled, { createGlobalStyle } from "styled-components";
-import Table, {
-  Column,
-  SortOption,
-  TableOptions,
-} from "../../components/Table";
+import Table, { Column, TableOptions } from "../../components/Table";
 import SearchBar from "../../components/SearchBar";
 import EnableSwitch from "../../components/EnableSwitch";
 import OutreachAlert from "./components/OutreachAlert";
+import OutreachCheckbox from "./components/OutreachCheckbox";
 import { useQuery } from "react-query";
 import auth from "../../api/core/auth";
 import { fetchMe, getPatients } from "../../api/userApi";
@@ -196,6 +193,16 @@ const cols: Column[] = [
     name: "Enable/Disable",
     data: (row) => <EnableSwitch _id={row._id} enabled={row.enabled} />,
     key: "unread",
+  },
+  {
+    name: "Outreach",
+    data: (row) => (
+      <OutreachCheckbox
+        _id={row._id}
+        outreachStatus={row?.outreach?.outreach || false}
+      />
+    ),
+    key: "outreach",
   },
   {
     name: "",

--- a/src/pages/PatientDashboard/components/OutreachAlert.test.tsx
+++ b/src/pages/PatientDashboard/components/OutreachAlert.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import OutreachAlert from "./OutreachAlert";
+import { render } from "@testing-library/react";
+
+describe("Outreach alert returns the proper icon", () => {
+  test("Outreach alert returns the checkmark icon", () => {
+    const { queryByTestId } = render(
+      <OutreachAlert
+        _id="kajsdhui2diu2hi21di21"
+        outreachYesStatus={true}
+        pending={false}
+      />
+    );
+    expect(queryByTestId("return-div-checkmark")).toBeTruthy();
+  });
+
+  test("Outreach alert returns the sleep icon", () => {
+    const { queryByTestId } = render(
+      <OutreachAlert
+        _id="kajsdhui2diu2hi21di21"
+        outreachYesStatus={false}
+        pending={true}
+      />
+    );
+    expect(queryByTestId("return-div-sleep")).toBeTruthy();
+  });
+
+  test("Outreach alert returns the exclamation icon", () => {
+    const { queryByTestId } = render(
+      <OutreachAlert
+        _id="kajsdhui2diu2hi21di21"
+        outreachYesStatus={true}
+        pending={true}
+      />
+    );
+    expect(queryByTestId("return-div-exclamation")).toBeTruthy();
+  });
+});

--- a/src/pages/PatientDashboard/components/OutreachAlert.tsx
+++ b/src/pages/PatientDashboard/components/OutreachAlert.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import secureAxios from "../../../api/core/apiClient";
+import "remixicon/fonts/remixicon.css";
+
+export interface CheckedProps {
+  _id: string;
+  outreachYesStatus: boolean;
+  pending: boolean;
+}
+
+const OutreachAlert: React.FC<CheckedProps> = ({
+  _id,
+  outreachYesStatus,
+  pending,
+}: CheckedProps) => {
+  const handleChange = () => {
+    const confirmation = window.confirm("Did you call the patient?");
+    if (confirmation) {
+      const data = {
+        id: _id,
+        pending: !pending,
+      };
+      secureAxios
+        .put("/api/patients/outreach/pending", data)
+        .then((res) => {
+          alert(`Status Changed!`);
+          window.location.reload();
+        })
+        .catch((err) => {
+          alert("Failed to change patient status!");
+        });
+    }
+  };
+
+  //If the outreach process has completed
+  if (outreachYesStatus && !pending) {
+    return (
+      <div
+        style={{ display: "flex", justifyContent: "center" }}
+        data-testid="return-div-checkmark"
+      >
+        <i
+          className="fas fa-check"
+          style={{ color: "black", fontSize: "28px" }}
+        ></i>
+      </div>
+    );
+  }
+
+  return outreachYesStatus && pending ? (
+    <div
+      style={{ display: "flex", justifyContent: "center" }}
+      onClick={handleChange}
+      data-testid="return-div-exclamation"
+    >
+      <i
+        style={{ color: "black", fontSize: "28px" }}
+        className="fas fa-exclamation"
+      ></i>
+    </div>
+  ) : (
+    <div
+      style={{ display: "flex", justifyContent: "center" }}
+      data-testid="return-div-sleep"
+    >
+      <i style={{ fontSize: "32px" }} className="ri-zzz-line"></i>
+    </div>
+  );
+};
+
+export default OutreachAlert;

--- a/src/pages/PatientDashboard/components/OutreachAlert.tsx
+++ b/src/pages/PatientDashboard/components/OutreachAlert.tsx
@@ -2,17 +2,17 @@ import React from "react";
 import secureAxios from "../../../api/core/apiClient";
 import "remixicon/fonts/remixicon.css";
 
-export interface CheckedProps {
+export interface OutreachProps {
   _id: string;
   outreachYesStatus: boolean;
   pending: boolean;
 }
 
-const OutreachAlert: React.FC<CheckedProps> = ({
+const OutreachAlert: React.FC<OutreachProps> = ({
   _id,
   outreachYesStatus,
   pending,
-}: CheckedProps) => {
+}: OutreachProps) => {
   const handleChange = () => {
     const confirmation = window.confirm("Did you call the patient?");
     if (confirmation) {

--- a/src/pages/PatientDashboard/components/OutreachCheckbox.tsx
+++ b/src/pages/PatientDashboard/components/OutreachCheckbox.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import secureAxios from "../../../api/core/apiClient";
+import { Checkbox } from "antd";
+import "remixicon/fonts/remixicon.css";
+import "antd/dist/antd.css";
+
+export interface CheckedProps {
+  _id: string;
+  outreachStatus: boolean;
+}
+
+const OutreachCheckbox: React.FC<CheckedProps> = ({
+  _id,
+  outreachStatus,
+}: CheckedProps) => {
+  const handleChange = () => {
+    const data = {
+      id: _id,
+      outreach: !outreachStatus,
+    };
+    secureAxios
+      .put("/api/patients/outreach/outreach", data)
+      .then((res) => {
+        alert(`Status Changed!`);
+        window.location.reload();
+      })
+      .catch((err) => {
+        alert("Failed to change patient status!");
+      });
+  };
+
+  //If the outreach process has completed
+  return (
+    <div style={{ display: "flex", justifyContent: "center" }}>
+      <Checkbox onChange={handleChange} checked={outreachStatus} />
+    </div>
+  );
+};
+
+export default OutreachCheckbox;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10191,6 +10191,11 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remixicon@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/remixicon/-/remixicon-2.5.0.tgz#b5e245894a1550aa23793f95daceadbf96ad1a41"
+  integrity sha512-q54ra2QutYDZpuSnFjmeagmEiN9IMo56/zz5dDNitzKD23oFRw77cWo4TsrAdmdkPiEn8mxlrTqxnkujDbEGww==
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"


### PR DESCRIPTION
## Purpose  
Create an Outreach Call Alert on Patient Dashboard page

## Changes and Additions  		 
- `AddPatientForm.tsx` Added the pending variable to outreach. `Pending = true` means that the patient needs to be called.
- `Table.tsx`Added background color prop for columns.
-  `PatientDashboard.tsx` Added outreach column.
-  `OutreachAlert.tsx` Logic to display the adequate icon and the proper background color for the table.

## Open Trello Tickets
-[Outreach Call Alert on Patient Dashboard page](https://trello.com/c/ItbdCkkj/91-outreach-call-alert-on-patient-dashboard-page)

## Tested
- Branch is up to date to Master Branch
- Ran `yarn lint` before MR
- Ran `yarn test` before MR
- Application runs without crashes (`yarn start`)

![Screen Shot 2021-06-09 at 12 44 22](https://user-images.githubusercontent.com/13635035/121405122-46dea700-c922-11eb-83c3-6fd8be6df1c7.png)

![Screen Shot 2021-06-09 at 12 44 29](https://user-images.githubusercontent.com/13635035/121405130-49410100-c922-11eb-8cc7-0bc0c968d7cf.png)

