### PR TITLE
Bug/SMSFormat without commit clutter

### DIFF
--- a/src/components/SMSTile.tsx
+++ b/src/components/SMSTile.tsx
@@ -79,7 +79,7 @@ const TextBubbleText = styled.div`
   padding-bottom: 5px;
   padding-left: 16px;
   padding-right: 16px;
-  text-align: center;
+  white-space: pre-wrap;
 `;
 const SendButton = styled.button`
   background-color: white;
@@ -115,7 +115,7 @@ const SendInputContainer = styled.div``;
 
 const SendButtonContainer = styled.div``;
 
-const SendInput = styled.input`
+const SendInput = styled.textarea`
   background-color: #dde1e7;
   border-radius: 12px;
   padding: 8px 20px 8px 32px;
@@ -252,18 +252,25 @@ const SMSTile: React.FC<SMSProps> = ({
             e.preventDefault();
           }}
         >
-          <div className="field has-addons" style={{ padding: "20px" }}>
-            <div className="control" style={{ width: "100%" }}>
+          <div
+            className="field has-addons"
+            style={{ padding: "20px", height: "75px" }}
+          >
+            <div className="control" style={{ width: "100%", display: "flex" }}>
               <SendInput
                 name="query"
-                type="text"
                 placeholder="Enter your response..."
                 onChange={textChange}
                 value={newMsg}
               />
 
               {!showEmoji && (
-                <a onClick={showEmojis}>{String.fromCodePoint(0x1f60a)}</a>
+                <a
+                  onClick={showEmojis}
+                  style={{ alignSelf: "center", marginLeft: "9px" }}
+                >
+                  {String.fromCodePoint(0x1f60a)}
+                </a>
               )}
             </div>
             <div className="control">


### PR DESCRIPTION
## Purpose  
- Copy/Pasting text keeps the original formatting
- Add ability to indent text

## Changes and Additions  		 
- In `SMSTitle.tsx` added css `white-space: pre-wrap;`to keep newline formatting
- In `SMSTitle.tsx` added changed `SendInput` `input to `textarea`
- In `SMSTitle.tsx` added css to the  `<div>` parent of `SendInput` and to `showEmoji`so everything stays in place with the `textarea` change


## Open Trello Tickets

-[CSV parsing is broken in some instances; messages received from clients are being parsed into the incorrect columns w/in CSV](https://trello.com/c/vg6quwJu/74-csv-parsing-is-broken-in-some-instances-messages-received-from-clients-are-being-parsed-into-the-incorrect-columns-w-in-csv)

## Tested
- Branch is up to date to Master Branch
- Ran `yarn lint` before MR
- Ran `yarn test` before MR
- Application runs without crashes (`yarn start`)

Proof of fix (MacOS)
![Screen Shot 2021-05-26 at 11 25 30](https://user-images.githubusercontent.com/13635035/119699026-68ff0200-be17-11eb-9a0a-4f906208a155.png)
