### PR TITLE
Add ability to deploy to staging using GH actions

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,23 @@
+name: Manually deploy to staging
+
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Install SSH key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        known_hosts: 'just-a-placeholder-so-we-dont-get-errors'
+        if_key_exists: fail
+    - name: Adding Known Hosts
+      run: ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+    - name: aptible-staging
+      run: git remote add aptible-staging ${{ secrets.APTIBLE_GIT_STAGING }}
+    - name: push aptible
+      run: bin/release_staging.sh


### PR DESCRIPTION
- Purpose
Manually push to staging with GitHub actions in Aptible.

- needs:
 - SSH_PRIVATE_KEY = the private key -----BEGIN OPENSSH PRIVATE KEY------ 
 - SSH_HOST = aptible.com
 - APTIBLE_GIT_STAGING = git@aptible.com:APPNAME.git

- Test in Heroku:
https://github.com/g-vega-cl/ssh-github
https://ssh-github.herokuapp.com
