### PR TITLE
Add outreach checkbox in Add Patient Form

### DIFF
--- a/src/components/AddPatientForm.tsx
+++ b/src/components/AddPatientForm.tsx
@@ -81,12 +81,18 @@ const EnabledInput = styled.input`
   margin: 0 10px 20px 20px;
 `;
 
+const OutreachInput = styled.input`
+  margin: 0 10px 20px 12px;
+`;
+
 const initialValues = {
   firstName: "",
   lastName: "",
   language: "",
   coachId: "",
   phoneNumber: "",
+  clinic: "",
+  msgTime: "",
 };
 
 const FieldWrapper = ({
@@ -121,6 +127,8 @@ const AddPatientForm: React.FC = () => {
   const [phoneNum, setPhoneNum] = useState("");
   const [coachId, setCoachId] = useState("");
   const [isEnabled, setEnabled] = useState(true);
+  const [isOutreach, setOutreach] = useState(true);
+  const [clinic, setClinic] = useState("");
   const [msgTime, setTime] = useState("00:00");
 
   const [coachName, setCoachName] = useState("");
@@ -139,6 +147,15 @@ const AddPatientForm: React.FC = () => {
         isEnabled,
         msgTime,
         coachName,
+        clinic,
+        outreach: {
+          outreach: isOutreach,
+          more: false,
+          yes: false,
+          complete: false,
+          lastMessageSent: "0",
+          lastDate: new Date(),
+        },
       })
       .then((res) => {
         setMessage(
@@ -244,6 +261,16 @@ const AddPatientForm: React.FC = () => {
             />
           </FieldWrapper>
 
+          <FieldWrapper icon="fa-hospital">
+            <Field
+              name="clinic"
+              style={inputStyles}
+              type="text"
+              placeholder="Refered clinic"
+              className="form-field"
+              onInput={(e: any) => setClinic(e.target.value)}
+            />
+          </FieldWrapper>
           <FieldWrapper icon="fa-clock">
             <Field
               name="msgTime"
@@ -280,6 +307,19 @@ const AddPatientForm: React.FC = () => {
                 name="enabled"
                 checked={isEnabled}
                 onChange={(e) => setEnabled(e.target.checked)}
+              />
+            </label>
+          </div>
+
+          <div>
+            <label>
+              {" "}
+              Outreach:
+              <OutreachInput
+                type="checkbox"
+                name="outreach"
+                checked={isOutreach}
+                onChange={(e) => setOutreach(e.target.checked)}
               />
             </label>
           </div>


### PR DESCRIPTION
Purpose
- Add a checkbox to indicate that outreach should be enabled in `AddPatientForm.tsx` 

Trello:
- https://trello.com/c/nWII8e4D/89-automated-outreach-messages-to-new-patients

Tests:
- Outreach messages are sent when the outreach checkbox is enabled.