### PR TITLE
Add outreach patient status

### DIFF
--- a/src/api/utils.test.ts
+++ b/src/api/utils.test.ts
@@ -1,0 +1,67 @@
+import getPatientStatus from "./utils";
+
+describe("getPatientStatus returns the expected value ", () => {
+  it("returns Enrolled ✅ if outreach is complete ", () => {
+    const data = {
+      enabled: true,
+      outreach: {
+        outreach: false,
+        yes: false,
+        complete: true,
+        lastMessageSent: "1",
+        lastDate: new Date(),
+      },
+    };
+    expect(getPatientStatus(data)).toBe("Enrolled ✅");
+  });
+  it("returns Not Sent 💤 if outreach is off ", () => {
+    const data = {
+      enabled: true,
+      outreach: {
+        outreach: false,
+        yes: false,
+        complete: false,
+      },
+    };
+    expect(getPatientStatus(data)).toBe("Not Sent 💤");
+  });
+  it("returns Yes ❗️ if outreach is yes ", () => {
+    const data = {
+      enabled: true,
+      outreach: {
+        outreach: true,
+        yes: true,
+        complete: false,
+        lastMessageSent: "1",
+        lastDate: new Date(),
+      },
+    };
+    expect(getPatientStatus(data)).toBe("Yes ❗️");
+  });
+  it("returns No Response 🔴 if outreach is ongoing ", () => {
+    const data = {
+      enabled: true,
+      outreach: {
+        outreach: true,
+        yes: false,
+        complete: false,
+        lastMessageSent: "1",
+        lastDate: new Date(),
+      },
+    };
+    expect(getPatientStatus(data)).toBe("No Response 🔴");
+  });
+  it("returns Disabled if patient is disabled", () => {
+    const data = {
+      enabled: false,
+      outreach: {
+        outreach: false,
+        yes: false,
+        complete: true,
+        lastMessageSent: "1",
+        lastDate: new Date(),
+      },
+    };
+    expect(getPatientStatus(data)).toBe("Disabled");
+  });
+});

--- a/src/api/utils.tsx
+++ b/src/api/utils.tsx
@@ -1,0 +1,21 @@
+const getPatientStatus = (data: any) => {
+  if (data.enabled) {
+    if (data.outreach.complete) {
+      return `Enrolled ✅`;
+    } else {
+      if (!data.outreach.outreach) {
+        return `Not Sent 💤`;
+      } else {
+        if (data.outreach.yes) {
+          return `Yes ❗️`;
+        } else {
+          return `No Response 🔴`;
+        }
+      }
+    }
+  } else {
+    return "Disabled";
+  }
+};
+
+export default getPatientStatus;

--- a/src/pages/PatientDashboard.tsx
+++ b/src/pages/PatientDashboard.tsx
@@ -6,6 +6,7 @@ import EnableSwitch from "../components/EnableSwitch";
 import { useQuery } from "react-query";
 import auth from "../api/core/auth";
 import { fetchMe, getPatients } from "../api/userApi";
+import getPatientStatus from "../api/utils";
 
 const DashboardContainer = styled.div`
   padding: 20px;
@@ -139,7 +140,7 @@ const tableOptions: TableOptions = {
 const cols: Column[] = [
   {
     name: "Status",
-    data: "status",
+    data: (row) => <React.Fragment>{getPatientStatus(row)}</React.Fragment>,
     key: "status",
   },
   {


### PR DESCRIPTION
Purpose
- Allow coaches to see the outreach status of a patient

Trello:
- https://trello.com/c/ItbdCkkj/91-outreach-call-alert-on-patient-dashboard-page