### PR TITLE
Add Nudge option to Message Template Form

### DIFF
--- a/src/components/MessageTemplateForm.tsx
+++ b/src/components/MessageTemplateForm.tsx
@@ -169,6 +169,7 @@ const MessageTemplateForm: React.FC = () => {
             <label>Select message type: </label>
             <Field as="select" name="type">
               <option value="Initial">Initial</option>
+              <option value="Nudge">Nudge</option>
               <option value="Green">Green</option>
               <option value="Yellow">Yellow</option>
               <option value="Red">Red</option>


### PR DESCRIPTION
Purpose:

- Adding Nudge type option to Message Template form to go along with associated backend PR: https://github.com/coachmehealth/sms-care-portal-backend/pull/76

Trello:

- https://trello.com/c/u4Kea7sx
